### PR TITLE
Update 404.html to adjust pathSegmentsToKeep for improved URL handling

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -18,7 +18,7 @@
     // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
     // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
     // Otherwise, leave pathSegmentsToKeep as 0.
-    var pathSegmentsToKeep = 1;
+    var pathSegmentsToKeep = 0;
 
     var l = window.location;
     l.replace(


### PR DESCRIPTION
- Changed pathSegmentsToKeep from 1 to 0 in 404.html to ensure correct redirection behavior for GitHub Pages deployment. This change enhances the maintainability of the application by clarifying the handling of URL segments.